### PR TITLE
fix scope for facebook social auth

### DIFF
--- a/src/facebook-auth/FacebookAuth.svelte
+++ b/src/facebook-auth/FacebookAuth.svelte
@@ -83,6 +83,6 @@
       } else {
         dispatch('auth-info', { response })
       }
-    }, { scope: 'email,public_profile' })
+    }, { scope: 'public_profile, email' })
   }
 </script>


### PR DESCRIPTION
i notice that facebook don't give me user email after logged in only id and name. But fixed properly when scope changed.
My code for is
>`  function getCurrentUserInfo() {
    const FB = window["FB"];
    FB.api("/me", { fields: "name, email" }, function (userInfo) {
      console.log(userInfo);
    });
 }`