### PR TITLE
Outdated initialization method - Update GoogleAuth.svelte

### DIFF
--- a/src/lib/google-auth/GoogleAuth.svelte
+++ b/src/lib/google-auth/GoogleAuth.svelte
@@ -74,7 +74,7 @@
 
   function initialise () {
     gapi.load('auth2', async () => {
-      googleAuth = gapi.auth2.init({ client_id: clientId })
+      googleAuth = gapi.auth2.getAuthInstance({ client_id: clientId })
       googleAuth.then(attachHandler, handleInitialisationError)
     })
   }


### PR DESCRIPTION
i received errors directly from google on this:
Uncaught (in promise)
VH
: 
true
message
: 
"gapi.auth2 has been initialized with different options. Consider calling gapi.auth2.getAuthInstance() instead of gapi.auth2.init()." stack
: 
"gapi.auth2.ExternallyVisibleError: gapi.auth2 has been initialized with different options. Consider calling gapi.auth2.getAuthInstance() instead of gapi.auth2.init().\n